### PR TITLE
fix: migrations failures due to duplicate PLC signature requests

### DIFF
--- a/routes/api/cred/login.ts
+++ b/routes/api/cred/login.ts
@@ -25,12 +25,15 @@ export const handler = define.handlers({
           {
             status: 400,
             headers: { "Content-Type": "application/json" },
-          },
+          }
         );
       }
 
       console.log("Resolving handle:", handle);
-      const did = await resolver.resolveHandleToDid(handle);
+      const did =
+        typeof handle == "string" && handle.startsWith("did:")
+          ? handle
+          : await resolver.resolveHandleToDid(handle);
       const service = await resolver.resolveDidToPdsUrl(did);
       console.log("Resolved service:", service);
 
@@ -42,7 +45,7 @@ export const handler = define.handlers({
           }),
           {
             status: 400,
-          },
+          }
         );
       }
 
@@ -70,7 +73,7 @@ export const handler = define.handlers({
           {
             status: 200,
             headers: { "Content-Type": "application/json" },
-          },
+          }
         );
 
         // Create and save our client session with tokens
@@ -100,7 +103,7 @@ export const handler = define.handlers({
           {
             status: 401,
             headers: { "Content-Type": "application/json" },
-          },
+          }
         );
       }
     } catch (error) {
@@ -114,7 +117,7 @@ export const handler = define.handlers({
         {
           status: 500,
           headers: { "Content-Type": "application/json" },
-        },
+        }
       );
     }
   },


### PR DESCRIPTION
- Adds guards to prevent duplicate PLC requests that cause migrations to fail
- Allow users to enter DIDs instead of handles

<sub><sup>*thanks claude opus 4.1!*</sup></sub>